### PR TITLE
switched apply-all.sh script to use optional metadata/annotations

### DIFF
--- a/305-cloud-pak-for-data-foundation/bom.yaml
+++ b/305-cloud-pak-for-data-foundation/bom.yaml
@@ -41,19 +41,22 @@ spec:
       version: v1.11.2
       variables:
         - name: name
-          value: ibm-common-services
+          alias: ibm_common_services_namespace
+          scope: global
     - name: gitops-namespace
       alias: cpd_operators_namespace
       version: v1.11.2
       variables:
         - name: name
-          value: cpd-operators
+          alias: cpd_operators_namespace
+          scope: global
     - name: gitops-namespace
       alias: cp4d_namespace
       version: v1.11.2
       variables:
         - name: name
-          value: cp4d
+          alias: cp4d_namespace
+          scope: global
     - name: gitops-repo
       alias: gitops_repo
       version: v1.18.1
@@ -65,6 +68,18 @@ spec:
         registry. Visit https://myibm.ibm.com/products-services/containerlibrary
         to get the key
       sensitive: true
+    - name: ibm_common_services_namespace
+      type: string
+      description: The value that should be used for the namespace
+      defaultValue: ibm-common-services
+    - name: cpd_operators_namespace
+      type: string
+      description: The value that should be used for the namespace
+      defaultValue: cpd-operators
+    - name: cp4d_namespace
+      type: string
+      description: The value that should be used for the namespace
+      defaultValue: cp4d
     - name: gitops_repo_host
       type: string
       description: The host for the git repository.

--- a/305-cloud-pak-for-data-foundation/terraform/305-cloud-pak-for-data-foundation.auto.tfvars
+++ b/305-cloud-pak-for-data-foundation/terraform/305-cloud-pak-for-data-foundation.auto.tfvars
@@ -1,6 +1,15 @@
 ## entitlement_key: The entitlement key used to access the CP4I images in the container registry. Visit https://myibm.ibm.com/products-services/containerlibrary to get the key
 #entitlement_key=""
 
+## ibm_common_services_namespace: The value that should be used for the namespace
+#ibm_common_services_namespace="ibm-common-services"
+
+## cpd_operators_namespace: The value that should be used for the namespace
+#cpd_operators_namespace="cpd-operators"
+
+## cp4d_namespace: The value that should be used for the namespace
+#cp4d_namespace="cp4d"
+
 ## gitops_repo_host: The host for the git repository.
 #gitops_repo_host=""
 

--- a/305-cloud-pak-for-data-foundation/terraform/main.tf
+++ b/305-cloud-pak-for-data-foundation/terraform/main.tf
@@ -6,7 +6,7 @@ module "cp4d_namespace" {
   create_operator_group = var.cp4d_namespace_create_operator_group
   git_credentials = module.gitops_repo.git_credentials
   gitops_config = module.gitops_repo.gitops_config
-  name = var.cp4d_namespace_name
+  name = var.cp4d_namespace
   server_name = module.gitops_repo.server_name
 }
 module "cp4d-instance" {
@@ -32,7 +32,7 @@ module "cpd_operators_namespace" {
   create_operator_group = var.cpd_operators_namespace_create_operator_group
   git_credentials = module.gitops_repo.git_credentials
   gitops_config = module.gitops_repo.gitops_config
-  name = var.cpd_operators_namespace_name
+  name = var.cpd_operators_namespace
   server_name = module.gitops_repo.server_name
 }
 module "gitops_repo" {
@@ -82,6 +82,6 @@ module "ibm_common_services_namespace" {
   create_operator_group = var.ibm_common_services_namespace_create_operator_group
   git_credentials = module.gitops_repo.git_credentials
   gitops_config = module.gitops_repo.gitops_config
-  name = var.ibm_common_services_namespace_name
+  name = var.ibm_common_services_namespace
   server_name = module.gitops_repo.server_name
 }

--- a/305-cloud-pak-for-data-foundation/terraform/variables.tf
+++ b/305-cloud-pak-for-data-foundation/terraform/variables.tf
@@ -37,7 +37,7 @@ variable "entitlement_key" {
   type = string
   description = "The entitlement key used to access the CP4I images in the container registry. Visit https://myibm.ibm.com/products-services/containerlibrary to get the key"
 }
-variable "ibm_common_services_namespace_name" {
+variable "ibm_common_services_namespace" {
   type = string
   description = "The value that should be used for the namespace"
   default = "ibm-common-services"
@@ -57,7 +57,7 @@ variable "ibm_common_services_namespace_argocd_namespace" {
   description = "The namespace where argocd has been deployed"
   default = "openshift-gitops"
 }
-variable "cpd_operators_namespace_name" {
+variable "cpd_operators_namespace" {
   type = string
   description = "The value that should be used for the namespace"
   default = "cpd-operators"
@@ -77,7 +77,7 @@ variable "cpd_operators_namespace_argocd_namespace" {
   description = "The namespace where argocd has been deployed"
   default = "openshift-gitops"
 }
-variable "cp4d_namespace_name" {
+variable "cp4d_namespace" {
   type = string
   description = "The value that should be used for the namespace"
   default = "cp4d"

--- a/310-cloud-pak-for-data-db2uoperator/bom.yaml
+++ b/310-cloud-pak-for-data-db2uoperator/bom.yaml
@@ -8,11 +8,20 @@ metadata:
   annotations:
     displayName: DB2UOperator for Cloud Pak for Data
     description: GitOps deployment of DB2U Operator for Cloud pak for Data
+    apply-all/optional: 'true'
 spec:
   modules:
     - name: gitops-db2u
       alias: gitops-db2u
       version: v1.1.0
+      variables:
+        - name: operator_namespace
+          alias: cpd_operators_namespace
+          scope: global
+        - name: channel
+          value: v1.1
+        - name: subscription_source_namespace
+          value: openshift-marketplace
       dependencies:
         - name: namespace
           ref: gitops-db2u_namespace
@@ -34,16 +43,14 @@ spec:
       variables:
         - name: name
           value: gitops-db2u
-        - name: operator_namespace
-          value: cpd-operators
-        - name: channel
-          value: v1.1
-        - name: subscription_source_namespace
-          value: openshift-marketplace
     - name: gitops-repo
       alias: gitops_repo
       version: v1.18.1
   variables:
+    - name: cpd_operators_namespace
+      type: string
+      description: The namespace where the operators will be installed
+      defaultValue: cpd-operators
     - name: gitops_repo_host
       type: string
       description: The host for the git repository.

--- a/310-cloud-pak-for-data-db2uoperator/terraform/310-cloud-pak-for-data-db2uoperator.auto.tfvars
+++ b/310-cloud-pak-for-data-db2uoperator/terraform/310-cloud-pak-for-data-db2uoperator.auto.tfvars
@@ -1,3 +1,6 @@
+## cpd_operators_namespace: The namespace where the operators will be installed
+#cpd_operators_namespace="cpd-operators"
+
 ## gitops_repo_host: The host for the git repository.
 #gitops_repo_host=""
 

--- a/310-cloud-pak-for-data-db2uoperator/terraform/main.tf
+++ b/310-cloud-pak-for-data-db2uoperator/terraform/main.tf
@@ -25,7 +25,7 @@ module "gitops-db2u" {
   git_credentials = module.gitops_repo.git_credentials
   gitops_config = module.gitops_repo.gitops_config
   kubeseal_cert = module.gitops_repo.sealed_secrets_cert
-  operator_namespace = var.gitops-db2u_operator_namespace
+  operator_namespace = var.cpd_operators_namespace
   server_name = module.gitops_repo.server_name
   subscription_source = var.gitops-db2u_subscription_source
   subscription_source_namespace = var.gitops-db2u_subscription_source_namespace

--- a/310-cloud-pak-for-data-db2uoperator/terraform/variables.tf
+++ b/310-cloud-pak-for-data-db2uoperator/terraform/variables.tf
@@ -8,7 +8,7 @@ variable "gitops-db2u_subscription_source_namespace" {
   description = "The namespace where the catalog has been deployed"
   default = "openshift-marketplace"
 }
-variable "gitops-db2u_operator_namespace" {
+variable "cpd_operators_namespace" {
   type = string
   description = "The namespace where the operators will be installed"
   default = "cpd-operators"
@@ -16,7 +16,7 @@ variable "gitops-db2u_operator_namespace" {
 variable "gitops-db2u_channel" {
   type = string
   description = "The channel that should be used to deploy the operator"
-  default = "v1.0"
+  default = "v1.1"
 }
 variable "gitops-db2u_namespace_name" {
   type = string

--- a/315-cloud-pak-for-data-db2wh/bom.yaml
+++ b/315-cloud-pak-for-data-db2wh/bom.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     displayName: DB2 Warehouse for Cloud Pak for Data
     description: GitOps deployment of DB2 Warehouse for Cloud pak for Data
+    apply-all/optional: 'true'
 spec:
   modules:
     - name: gitops-cp-db2wh
@@ -15,11 +16,14 @@ spec:
       version: v1.2.1
       variables:
         - name: common_services_namespace
-          value: ibm-common-services
+          alias: ibm_common_services_namespace
+          scope: global
         - name: operator_namespace
-          value: cpd-operators
+          alias: cpd_operators_namespace
+          scope: global
         - name: cpd_namespace
-          value: cp4d
+          alias: cp4d_namespace
+          scope: global
         - name: license
           value: Enterprise
         - name: db2_warehouse_channel
@@ -55,6 +59,18 @@ spec:
       alias: gitops_repo
       version: v1.18.1
   variables:
+    - name: cpd_operators_namespace
+      type: string
+      description: CPD operator namespace
+      defaultValue: cpd-operators
+    - name: cp4d_namespace
+      type: string
+      description: CPD namespace
+      defaultValue: cp4d
+    - name: ibm_common_services_namespace
+      type: string
+      description: Namespace where cpd is deployed
+      defaultValue: ibm-common-services
     - name: gitops_repo_host
       type: string
       description: The host for the git repository.

--- a/315-cloud-pak-for-data-db2wh/terraform/315-cloud-pak-for-data-db2wh.auto.tfvars
+++ b/315-cloud-pak-for-data-db2wh/terraform/315-cloud-pak-for-data-db2wh.auto.tfvars
@@ -1,3 +1,12 @@
+## cpd_operators_namespace: CPD operator namespace
+#cpd_operators_namespace="cpd-operators"
+
+## cp4d_namespace: CPD namespace
+#cp4d_namespace="cp4d"
+
+## ibm_common_services_namespace: Namespace where cpd is deployed
+#ibm_common_services_namespace="ibm-common-services"
+
 ## gitops_repo_host: The host for the git repository.
 #gitops_repo_host=""
 

--- a/315-cloud-pak-for-data-db2wh/terraform/main.tf
+++ b/315-cloud-pak-for-data-db2wh/terraform/main.tf
@@ -24,8 +24,8 @@ module "gitops-cp-db2wh" {
   channel = var.gitops-cp-db2wh_channel
   cluster_ingress_hostname = var.gitops-cp-db2wh_cluster_ingress_hostname
   cluster_type = var.gitops-cp-db2wh_cluster_type
-  common_services_namespace = var.gitops-cp-db2wh_common_services_namespace
-  cpd_namespace = var.gitops-cp-db2wh_cpd_namespace
+  common_services_namespace = var.ibm_common_services_namespace
+  cpd_namespace = var.cp4d_namespace
   db2_warehouse_channel = var.gitops-cp-db2wh_db2_warehouse_channel
   db2_warehouse_version = var.gitops-cp-db2wh_db2_warehouse_version
   git_credentials = module.gitops_repo.git_credentials
@@ -33,7 +33,7 @@ module "gitops-cp-db2wh" {
   kubeseal_cert = module.gitops_repo.sealed_secrets_cert
   license = var.gitops-cp-db2wh_license
   namespace = module.gitops-cp-db2wh_namespace.name
-  operator_namespace = var.gitops-cp-db2wh_operator_namespace
+  operator_namespace = var.cpd_operators_namespace
   server_name = module.gitops_repo.server_name
   storage_class = var.gitops-cp-db2wh_storage_class
   subscription_source_namespace = var.gitops-cp-db2wh_subscription_source_namespace

--- a/315-cloud-pak-for-data-db2wh/terraform/variables.tf
+++ b/315-cloud-pak-for-data-db2wh/terraform/variables.tf
@@ -23,17 +23,17 @@ variable "gitops-cp-db2wh_channel" {
   description = "The channel that should be used to deploy the operator"
   default = "v1.0"
 }
-variable "gitops-cp-db2wh_operator_namespace" {
+variable "cpd_operators_namespace" {
   type = string
   description = "CPD operator namespace"
   default = "cpd-operators"
 }
-variable "gitops-cp-db2wh_cpd_namespace" {
+variable "cp4d_namespace" {
   type = string
   description = "CPD namespace"
   default = "cp4d"
 }
-variable "gitops-cp-db2wh_common_services_namespace" {
+variable "ibm_common_services_namespace" {
   type = string
   description = "Namespace where cpd is deployed"
   default = "ibm-common-services"

--- a/320-cloud-pak-for-data-db2oltp/bom.yaml
+++ b/320-cloud-pak-for-data-db2oltp/bom.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     displayName: DB2 OLTP for Cloud Pak for Data
     description: GitOps deployment of DB2 OLTP for Cloud pak for Data
+    apply-all/optional: 'true'
 spec:
   modules:
     - name: gitops-db2-oltp
@@ -15,11 +16,14 @@ spec:
       version: v1.0.12
       variables:
         - name: common_services_namespace
-          value: ibm-common-services
+          alias: ibm_common_services_namespace
+          scope: global
         - name: operator_namespace
-          value: cpd-operators
+          alias: cpd_operators_namespace
+          scope: global
         - name: cpd_namespace
-          value: cp4d
+          alias: cp4d_namespace
+          scope: global
         - name: subscription_source_namespace
           value: openshift-marketplace
         - name: license
@@ -55,6 +59,18 @@ spec:
       alias: gitops_repo
       version: v1.18.1
   variables:
+    - name: cpd_operators_namespace
+      type: string
+      description: CPD operator namespace
+      defaultValue: cpd-operators
+    - name: cp4d_namespace
+      type: string
+      description: CPD namespace
+      defaultValue: cp4d
+    - name: ibm_common_services_namespace
+      type: string
+      description: IBM Common Services namespace
+      defaultValue: ibm-common-services
     - name: gitops_repo_host
       type: string
       description: The host for the git repository.

--- a/320-cloud-pak-for-data-db2oltp/terraform/320-cloud-pak-for-data-db2oltp.auto.tfvars
+++ b/320-cloud-pak-for-data-db2oltp/terraform/320-cloud-pak-for-data-db2oltp.auto.tfvars
@@ -1,3 +1,12 @@
+## cpd_operators_namespace: CPD operator namespace
+#cpd_operators_namespace="cpd-operators"
+
+## cp4d_namespace: CPD namespace
+#cp4d_namespace="cp4d"
+
+## ibm_common_services_namespace: IBM Common Services namespace
+#ibm_common_services_namespace="ibm-common-services"
+
 ## gitops_repo_host: The host for the git repository.
 #gitops_repo_host=""
 

--- a/320-cloud-pak-for-data-db2oltp/terraform/main.tf
+++ b/320-cloud-pak-for-data-db2oltp/terraform/main.tf
@@ -34,14 +34,14 @@ module "gitops-db2-oltp" {
 
   channel = var.gitops-db2-oltp_channel
   cluster_name = var.gitops-db2-oltp_cluster_name
-  common_services_namespace = var.gitops-db2-oltp_common_services_namespace
-  cpd_namespace = var.gitops-db2-oltp_cpd_namespace
+  common_services_namespace = var.ibm_common_services_namespace
+  cpd_namespace = var.cp4d_namespace
   git_credentials = module.gitops_repo.git_credentials
   gitops_config = module.gitops_repo.gitops_config
   kubeseal_cert = module.gitops_repo.sealed_secrets_cert
   license = var.gitops-db2-oltp_license
   namespace = module.gitops-cp-db2oltp_namespace.name
-  operator_namespace = var.gitops-db2-oltp_operator_namespace
+  operator_namespace = var.cpd_operators_namespace
   server_name = module.gitops_repo.server_name
   subscription_source_namespace = var.gitops-db2-oltp_subscription_source_namespace
 }

--- a/320-cloud-pak-for-data-db2oltp/terraform/variables.tf
+++ b/320-cloud-pak-for-data-db2oltp/terraform/variables.tf
@@ -18,17 +18,17 @@ variable "gitops-db2-oltp_channel" {
   description = "The channel that should be used to deploy the operator"
   default = "v1.0"
 }
-variable "gitops-db2-oltp_operator_namespace" {
+variable "cpd_operators_namespace" {
   type = string
   description = "CPD operator namespace"
   default = "cpd-operators"
 }
-variable "gitops-db2-oltp_cpd_namespace" {
+variable "cp4d_namespace" {
   type = string
   description = "CPD namespace"
   default = "cp4d"
 }
-variable "gitops-db2-oltp_common_services_namespace" {
+variable "ibm_common_services_namespace" {
   type = string
   description = "IBM Common Services namespace"
   default = "ibm-common-services"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > This collection of Cloud Pak for Data terraform automation layers has been crafted from a set of  [Terraform modules](https://modules.cloudnativetoolkit.dev/) created by the IBM GSI Ecosystem Lab team part of the [IBM Partner Ecosystem organization](https://www.ibm.com/partnerworld/public?mhsrc=ibmsearch_a&mhq=partnerworld). Please contact **Matthew Perrins** _mjperrin@us.ibm.com_, **Sean Sundberg** _seansund@us.ibm.com_, **Tom Skill** _tskill@us.ibm.com_,  or **Andrew Trice** _amtrice@us.ibm.com_ for more details or raise an issue on the repository.
 
-The automation will support the installation of Data Foundation on three cloud platforms (AWS, Azure, and IBM Cloud).  Data Foundation is the minimum base layer of the Cloud Pak for Data that is required to install additional tools, services or cartridges, such as DB2 Warehouse, Data Virtualization, Watson Knowledge Studio, or multi-product solutions like Data Fabric. 
+The automation will support the installation of Data Foundation on three cloud platforms (AWS, Azure, and IBM Cloud).  Data Foundation is the minimum base layer of the Cloud Pak for Data that is required to install additional tools, services or cartridges, such as DB2 Warehouse, Data Virtualization, Watson Knowledge Studio, or multi-product solutions like Data Fabric.
 
 ### Target Infrastructure
 
@@ -30,7 +30,7 @@ The reference architectures are provided in three different forms, with increasi
 - **Advanced** - a more advanced deployment that employs network isolation to securely route traffic between the different layers.
 
 
-For each of these reference architecture, we have provided a detailed set of automation to create the environment for the software. If you do not have an OpenShift environment provisioned, please use one of these. They are optimized for the installation of this solution.  
+For each of these reference architecture, we have provided a detailed set of automation to create the environment for the software. If you do not have an OpenShift environment provisioned, please use one of these. They are optimized for the installation of this solution.
 
 Note:  [Cloud Pak for Data system requirements](https://www.ibm.com/docs/en/cloud-paks/cp-data/3.5.0?topic=planning-system-requirements) recommend at least 3 worker nodes, with minimum 16vCPU per node and minimum 64 GB RAM per done (128 GB RAM is recommended).
 
@@ -51,7 +51,7 @@ Within this repository you will find a set of Terraform template bundles that em
 This suite of automation can be used for a Proof of Technology environment, or used as a foundation for production workloads with a fully working end-to-end cloud-native environment. The software installs using **GitOps** best practices with [**Red Hat Open Shift GitOps**](https://docs.openshift.com/container-platform/4.8/cicd/gitops/understanding-openshift-gitops.html)
 
 
-## Data Foundation  Architecture  
+## Data Foundation  Architecture
 
 
 The following reference architecture represents the logical view of how Data Foundation works after it is installed.  Data Foundation is deployed with either Portworx or OpenShift Data Foundation storage, within an OpenShift Cluster, on the Cloud provider of your choice.
@@ -82,7 +82,7 @@ After you purchase Cloud Pak for Data, an entitlement API key for the software i
 
 ### Data Foundation Layered Installation
 
-The Data Foundation automation is broken into what we call layers of automation or bundles. The bundles enable SRE activities to be optimized. The automation is generic between clouds other than configuration storage options, which are platform specific. 
+The Data Foundation automation is broken into what we call layers of automation or bundles. The bundles enable SRE activities to be optimized. The automation is generic between clouds other than configuration storage options, which are platform specific.
 
 | BOM ID | Name                                                                                                                                                                                                                                                           | Description                                                                                                                                                | Run Time |
 |--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
@@ -93,6 +93,15 @@ The Data Foundation automation is broken into what we call layers of automation 
 
 
 > At this time the most reliable way of running this automation is with Terraform in your local machine either through a bootstrapped container image or with native tools installed. We provide a Container image that has all the common SRE tools installed. [CLI Tools Image,](https://quay.io/repository/ibmgaragecloud/cli-tools?tab=tags) [Source Code for CLI Tools](https://github.com/cloud-native-toolkit/image-cli-tools)
+
+#### Optional components
+
+The following components can be optionally deployed after Data Foundation has been deployed:
+
+| BOM ID | Name                                                                       | Description          | Run Time |
+|--------|----------------------------------------------------------------------------|----------------------|----------|
+| 315    | [315 - Cloud Pak for Data - DB2 Warehouse](./315-cloud-pak-for-data-db2wh) | Deploy DB2 Warehouse | 15 Mins   |
+| 320    | [315 - Cloud Pak for Data - DB2 OLTP](./320-cloud-pak-for-data-db2oltp)    | Deploy DB2 OLTP      | 15 Mins   |
 
 
 ## Installation Steps
@@ -175,8 +184,8 @@ A container image is used to provide a consistent runtime environment for the au
     code credential.properties
     ```
 
-    In the `credentials.properties` file you will need to populate the values for your deployment.
-    
+   In the `credentials.properties` file you will need to populate the values for your deployment.
+
     ```text
     ## Add the values for the Credentials to access the OpenShift Environment
     ## Instructions to access this information can be found in the README.MD
@@ -218,8 +227,8 @@ A container image is used to provide a consistent runtime environment for the au
     ## TF_VAR_azure_client_secret: The client id of the user for the Azure account. This is required if Azure portworx is used
     TF_VAR_azure_client_secret=
     ```
-   
-    > ⚠️ Do not wrap any values in `credentials.properties` in quotes
+
+   > ⚠️ Do not wrap any values in `credentials.properties` in quotes
 
 
 4. Add your Git Hub username and your Personal Access Token to `gitops_repo_username` and `gitops_repo_token`
@@ -293,7 +302,7 @@ You can install these clis on your local machine **OR** run the following comman
 ##### Set up the automation workspace
 
 
-7. (Optiona) If your corporate policy does not allow use of Docker Desktop, then you need to install **Colima** as an alternative
+7. (Optional) If your corporate policy does not allow use of Docker Desktop, then you need to install **Colima** as an alternative
 
     ```
     brew install colima
@@ -374,7 +383,7 @@ The following you will be prompted for and some suggested values.
 The `gitops-repo_repo`, `gitops-repo_token`, `entitlement_key`, `server_url`, and `cluster_login_token` values will be loaded automatically from the credentials.properties file that was configured in an earlier step.
 
 
-15. The `cp4d-instance_storage_vendor` variable should have already been populated by the `setup-workspace.sh` script. This should have the value `portworx` or `ocs`, depending on the selected storage option. 
+15. The `cp4d-instance_storage_vendor` variable should have already been populated by the `setup-workspace.sh` script. This should have the value `portworx` or `ocs`, depending on the selected storage option.
 
 16. You will see that the `repo_type` and `repo_host` are set to GitHub you can change these to other Git Providers, like GitHub Enterprise or GitLab.
 
@@ -389,8 +398,17 @@ The `gitops-repo_repo`, `gitops-repo_token`, `entitlement_key`, `server_url`, an
 21. Navigate into the `/workspaces/current` folder
 
     > ❗️ Do not skip this step.  You must execute from the `/workspaces/current` folder.
-    
-22. Navigate into the `200-openshift-gitops` folder and run the following commands
+
+
+##### Automated Deployment
+
+22. To perform the deployment automatically, execute the `./apply-all.sh` script in the `/workspaces/current`.  This will apply each of the Data Foundation layers sequentially.  This operation will complete in 10-15 minutes, and the Data Foundation will continue asycnchronously in the background.  This can take an additional 45 minutes.
+
+    Once complete, skip to the **Access the Data Foundation Deployment** section
+
+##### Manual Deployment
+
+23. You can also deploy each layer manually.  To begin, navigate into the `200-openshift-gitops` folder and run the following commands
 
     ```
     cd 200-openshift-gitops
@@ -415,22 +433,22 @@ The `gitops-repo_repo`, `gitops-repo_token`, `entitlement_key`, `server_url`, an
     terraform init
     terraform apply --auto-approve
     ```
+
+    > This folder will vary based on the platform and storage options that you selected in earlier steps. 
     
-    > This folder will vary based on the platform and storage options that you selected in earlier steps.
-26. 
     Storage configuration will run asynchronously in the background inside of the Cluster and should be complete within 10 minutes.
-    
-27. Change directories to the `300-cloud-pak-for-data-entitlement` folder and run the following commands to deploy entitlements into your cluster:
+
+26. Change directories to the `300-cloud-pak-for-data-entitlement` folder and run the following commands to deploy entitlements into your cluster:
 
     ```
     cd ../300-cloud-pak-for-data-entitlement
     terraform init
     terraform apply --auto-approve
     ```
-    
+
     > This step **does not** require worker nodes to be restarted as some other installation methods describe.
 
-28. Change directories to the `305-cloud-pak-for-data-foundation` folder and run the following commands to deploy Data Foundation into the cluster.
+29. Change directories to the `305-cloud-pak-for-data-foundation` folder and run the following commands to deploy Data Foundation into the cluster.
 
     ```
     cd ../305-cloud-pak-for-data-foundation
@@ -440,17 +458,25 @@ The `gitops-repo_repo`, `gitops-repo_token`, `entitlement_key`, `server_url`, an
 
     Data Foundation deployment will run asynchronously in the background, and may require up to 45 minutes to complete.
 
-29. You can check the progress of the deployment by opening up Argo CD (OpenShift GitOps).  From the OpenShift user interface, click on the Application menu 3x3 Icon on the header and select **Cluster Argo CD** menu item.)
+30. You can check the progress of the deployment by opening up Argo CD (OpenShift GitOps).  From the OpenShift user interface, click on the Application menu 3x3 Icon on the header and select **Cluster Argo CD** menu item.)
 
     This process will take between 30 and 45 minutes to complete.  During the deployment, several cluster projects/namespaces and deployments will be created.
 
-30. Once deployment is complete, go back into the OpenShift cluster user interface and navigate to view `Routes` for the `cp4d` namespace.  Here you can see the URL to the deployed Data Foundation instance.  Open this url in a new browser window.
+##### Access the Data Foundation Deployment
+
+31. Once deployment is complete, go back into the OpenShift cluster user interface and navigate to view `Routes` for the `cp4d` namespace.  Here you can see the URL to the deployed Data Foundation instance.  Open this url in a new browser window.
 
     ![Reference Architecture](images/cp4d-route.jpg)
 
-31. Navigate to `Secrets` in the `cp4d` namespace, and find the `admin-user-details` secret.  Copy the value of `initial_admin_password` key inside of that secret. 
+32. Navigate to `Secrets` in the `cp4d` namespace, and find the `admin-user-details` secret.  Copy the value of `initial_admin_password` key inside of that secret.
 
-32. Go back to the Cloud Pak for Data Foundation instance that you opened in a separate window.  Log in using the username `admin` with the password copied in the previous step.
+33. Go back to the Cloud Pak for Data Foundation instance that you opened in a separate window.  Log in using the username `admin` with the password copied in the previous step.
+
+### Optional Services
+
+- **DB2 OLTP** (Online transactional processing) - Please refer the instructions for [installing DB2 OLTP](README-DB2OLTP.md) on top of CP4D Data foundation
+
+- **DB2 Warehouse** Please refer the instructions for [installing DB2Warehouse](README-DB2WH.md) on top of CP4D Data foundation
 
 ## Summary
 
@@ -458,11 +484,6 @@ This concludes the instructions for installing *Data Foundation* on AWS, Azure, 
 
 Now that the Data Foundation deployment is complete you can deploy [Cloud Pak for Data services](https://www.ibm.com/docs/en/cloud-paks/cp-data/4.0?topic=integrations-services) into this cluster.
 
-### Installing Data source services (DB2OLTP / DB2Warehouse)
-
-- ⚠️⚠️⚠️⚠️⚠️⚠️ Pls refer the instructions for [installing DB2 OLTP](README-DB2OLTP.md) on top of CP4D Data foundation
-
-- ⚠️⚠️⚠️⚠️⚠️⚠️ Pls refer the instructions for [installing DB2Warehouse](README-DB2WH.md) on top of CP4D Data foundation
 
 ## Uninstalling & Troubleshooting
 

--- a/apply-all.sh
+++ b/apply-all.sh
@@ -12,6 +12,13 @@ find . -type d -maxdepth 1 | grep -vE "[.]/[.].*" | grep -vE "^[.]$" | grep -v w
 do
   name=$(echo "$dir" | sed -E "s~[.]/(.*)~\1~g")
 
+  OPTIONAL=$(grep "apply-all/optional" ./${name}/bom.yaml | sed -E "s~[^:]+: [\"'](.*)[\"']~\1~g")
+
+  if [[ "${OPTIONAL}" == "true" ]]; then
+    echo "***** Skipping optional step ${name} *****"
+    continue
+  fi
+
   VPN_REQUIRED=$(grep "vpn/required" ./${name}/bom.yaml | sed -E "s~[^:]+: [\"'](.*)[\"']~\1~g")
 
   if [[ "${VPN_REQUIRED}" == "true" ]]; then

--- a/setup-workspace.sh
+++ b/setup-workspace.sh
@@ -202,9 +202,9 @@ cp "${SCRIPT_DIR}/destroy-all.sh" "${WORKSPACE_DIR}/destroy-all.sh"
 WORKSPACE_DIR=$(cd "${WORKSPACE_DIR}"; pwd -P)
 
 if [[ "${PORTWORX_SPEC_FILE}" == "installed" ]]; then
-  ALL_ARCH="200|300|305"
+  ALL_ARCH="200|300|305|310|315|320"
 else
-  ALL_ARCH="200|210|300|305"
+  ALL_ARCH="200|210|300|305|310|315|320"
 fi
 
 echo "Setting up workspace in ${WORKSPACE_DIR}"
@@ -258,6 +258,7 @@ do
   mkdir -p ${name}
   cd "${name}"
 
+  cp -R "${SCRIPT_DIR}/${name}/bom.yaml" .
   cp -R "${SCRIPT_DIR}/${name}/terraform/"* .
   ln -s "${WORKSPACE_DIR}"/terraform.tfvars ./terraform.tfvars
   if [[ -n "${PORTWORX_SPEC_FILE_BASENAME}" ]]; then


### PR DESCRIPTION
switched apply-all.sh script to use optional metadata/annotations from BOMs, regenerated latest automation

Signed-off-by: Andrew Trice <amtrice@us.ibm.com>

fixes https://github.com/cloud-native-toolkit/software-everywhere/issues/271